### PR TITLE
[4주차] 박세렴 / [feat] Todo 수정 기능 및 localStorage 저장 기능 구현

### DIFF
--- a/src/components/Todo.jsx
+++ b/src/components/Todo.jsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import { useTodo } from "../contexts/TodoContext";
 import Button from "./Button"; 
 
+import { useState } from "react"; // 수정 모드 상태 관리
 
 const ItemWrapper = styled.li`
   margin-bottom: 1.5rem;
@@ -72,7 +73,7 @@ const CheckboxWrapper = styled.label`
   }
 
   input:checked + span::after {
-    content: \"✔️\";
+    content: "✔️";
     position: absolute;
     top: 50%;
     left: 50%;
@@ -85,6 +86,19 @@ const CheckboxWrapper = styled.label`
 function Todo({ task }) {
   const { toggleTask, deleteTask, editTask } = useTodo();
 
+  const [isEditing, setIsEditing] = useState(false); // 수정모드 여부
+  const [newName, setNewName] = useState(task.name); //  수정할 새로운 이름
+
+  function handleSave() {
+    editTask(task.id, newName); // 수정된 이름 저장
+    setIsEditing(false); // 다시 보기 모드로
+  }
+
+  function handleCancel() {
+    setNewName(task.name); // 원래 이름으로 되돌리고
+    setIsEditing(false); // 보기 모드로
+  }
+
   return (
     <ItemWrapper>
       <Row>
@@ -96,11 +110,33 @@ function Todo({ task }) {
           />
           <span></span>
         </CheckboxWrapper>
-        <span>{task.name}</span>
+
+        {/* 이름 대신 입력창 조건부 렌더링 */}
+        {isEditing ? (
+          <input
+            type="text"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            style={{ flex: 1, height: "30px", fontSize: "16px" }}
+          />
+        ) : (
+          <span>{task.name}</span>
+        )}
       </Row>
+
       <ButtonWrapper>
-        <EditButton onClick={() => editTask(task.id)}>Edit</EditButton>
-        <DeleteButton onClick={() => deleteTask(task.id)}>Delete</DeleteButton>
+        {/* 버튼도 Edit 모드에 따라 다르게 표시 */}
+        {isEditing ? (
+          <>
+            <EditButton onClick={handleSave}>Save</EditButton>
+            <DeleteButton onClick={handleCancel}>Cancel</DeleteButton>
+          </>
+        ) : (
+          <>
+            <EditButton onClick={() => setIsEditing(true)}>Edit</EditButton>
+            <DeleteButton onClick={() => deleteTask(task.id)}>Delete</DeleteButton>
+          </>
+        )}
       </ButtonWrapper>
     </ItemWrapper>
   );

--- a/src/components/Todo.jsx
+++ b/src/components/Todo.jsx
@@ -1,8 +1,9 @@
+// src/components/Todo.jsx
+
+import React, { useState } from "react";
 import styled from "styled-components";
 import { useTodo } from "../contexts/TodoContext";
-import Button from "./Button"; 
-
-import { useState } from "react"; // 수정 모드 상태 관리
+import Input from "./Input"; // 기존에 만든 Input 컴포넌트를 불러옵니다.
 
 const ItemWrapper = styled.li`
   margin-bottom: 1.5rem;
@@ -26,23 +27,48 @@ const ButtonWrapper = styled.div`
   }
 `;
 
-const EditButton = styled(Button)`
+const EditButton = styled.button`
   width: 380px;
+  padding: 8px;
+  background-color:rgb(255, 255, 255);
+  color: black;
+  border: 2px solid black;
+  font-size: 16px;
 
   @media (max-width: 480px) {
     width: 100%;
   }
 `;
 
-const DeleteButton = styled(Button)`
+const DeleteButton = styled.button`
   width: 380px;
+  padding: 8px;
   background-color: #c0392b;
-  color: #fff;
+  color: white;
   border: none;
+  font-size: 16px;
 
   @media (max-width: 480px) {
     width: 100%;
   }
+`;
+
+const SaveButton = styled.button`
+  flex: 1;
+  padding: 8px;
+  background-color: black;
+  color: white;
+  border: none;
+  font-size: 16px;
+`;
+
+const CancelButton = styled.button`
+  flex: 1;
+  padding: 8px;
+  background-color: white;
+  color: black;
+  border: 2px solid black;
+  font-size: 16px;
 `;
 
 const CheckboxWrapper = styled.label`
@@ -86,58 +112,55 @@ const CheckboxWrapper = styled.label`
 function Todo({ task }) {
   const { toggleTask, deleteTask, editTask } = useTodo();
 
-  const [isEditing, setIsEditing] = useState(false); // 수정모드 여부
-  const [newName, setNewName] = useState(task.name); //  수정할 새로운 이름
+  const [isEditing, setIsEditing] = useState(false);
+  const [newName, setNewName] = useState(task.name);
 
-  function handleSave() {
-    editTask(task.id, newName); // 수정된 이름 저장
-    setIsEditing(false); // 다시 보기 모드로
-  }
+  const handleSave = () => {
+    editTask(task.id, newName);
+    setIsEditing(false);
+  };
 
-  function handleCancel() {
-    setNewName(task.name); // 원래 이름으로 되돌리고
-    setIsEditing(false); // 보기 모드로
-  }
+  const handleCancel = () => {
+    setNewName(task.name);
+    setIsEditing(false);
+  };
 
   return (
     <ItemWrapper>
-      <Row>
-        <CheckboxWrapper>
-          <input
-            type="checkbox"
-            checked={task.completed}
-            onChange={() => toggleTask(task.id)}
-          />
-          <span></span>
-        </CheckboxWrapper>
-
-        {/* 이름 대신 입력창 조건부 렌더링 */}
-        {isEditing ? (
-          <input
+      {isEditing ? (
+        <>
+          <p>New name for {task.name}</p>
+          <Input
             type="text"
             value={newName}
             onChange={(e) => setNewName(e.target.value)}
-            style={{ flex: 1, height: "30px", fontSize: "16px" }}
+            style={{ height: "30px", fontSize: "16px", width: "100%" }}
           />
-        ) : (
-          <span>{task.name}</span>
-        )}
-      </Row>
+          <ButtonWrapper>
+            <CancelButton onClick={handleCancel}>Cancel</CancelButton>
+            <SaveButton onClick={handleSave}>Save</SaveButton>
+          </ButtonWrapper>
+        </>
+      ) : (
+        <>
+          <Row>
+            <CheckboxWrapper>
+              <input
+                type="checkbox"
+                checked={task.completed}
+                onChange={() => toggleTask(task.id)}
+              />
+              <span></span>
+            </CheckboxWrapper>
+            <span>{task.name}</span>
+          </Row>
 
-      <ButtonWrapper>
-        {/* 버튼도 Edit 모드에 따라 다르게 표시 */}
-        {isEditing ? (
-          <>
-            <EditButton onClick={handleSave}>Save</EditButton>
-            <DeleteButton onClick={handleCancel}>Cancel</DeleteButton>
-          </>
-        ) : (
-          <>
+          <ButtonWrapper>
             <EditButton onClick={() => setIsEditing(true)}>Edit</EditButton>
             <DeleteButton onClick={() => deleteTask(task.id)}>Delete</DeleteButton>
-          </>
-        )}
-      </ButtonWrapper>
+          </ButtonWrapper>
+        </>
+      )}
     </ItemWrapper>
   );
 }

--- a/src/contexts/TodoContext.jsx
+++ b/src/contexts/TodoContext.jsx
@@ -1,10 +1,20 @@
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useState, useEffect } from "react";
 
 const TodoContext = createContext();
 
 export function TodoProvider({ children }) {
-  const [tasks, setTasks] = useState([]);
+  // 초기 tasks를 localStorage에서 불러오기
+  const [tasks, setTasks] = useState(() => {
+    const storedTasks = localStorage.getItem("tasks");
+    return storedTasks ? JSON.parse(storedTasks) : [];
+  });
+
   const [filter, setFilter] = useState("All");
+
+  // tasks가 바뀔 때마다 localStorage에 저장하기
+  useEffect(() => {
+    localStorage.setItem("tasks", JSON.stringify(tasks));
+  }, [tasks]);
 
   const addTask = (name) => {
     setTasks((prev) => [...prev, { id: Date.now(), name, completed: false }]);
@@ -22,20 +32,34 @@ export function TodoProvider({ children }) {
     );
   };
 
-  const editTask = (id) => {
-    // 예시: 수정 기능은 별도 구현할 수 있음 (여기선 토글처럼 구성)
-    console.log("Edit task", id);
+  const editTask = (id, newName) => {
+    // Edit 기능 구현 (새로운 이름으로 수정)
+    setTasks((prev) =>
+      prev.map((task) =>
+        task.id === id ? { ...task, name: newName } : task
+      )
+    );
   };
 
   const filteredTasks = tasks.filter((task) => {
     if (filter === "All") return true;
     if (filter === "Active") return !task.completed;
     if (filter === "Completed") return task.completed;
+    return true; // 혹시 몰라서 추가
   });
 
   return (
     <TodoContext.Provider
-      value={{ tasks, addTask, deleteTask, toggleTask, editTask, filter, setFilter, filteredTasks }}
+      value={{
+        tasks,
+        addTask,
+        deleteTask,
+        toggleTask,
+        editTask,
+        filter,
+        setFilter,
+        filteredTasks,
+      }}
     >
       {children}
     </TodoContext.Provider>


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

Todo List에서 할 일 수정(Edit/Save/Cancel) 기능을 구현하고,  
tasks 상태를 localStorage에 저장하여 새로고침 이후에도 데이터가 유지되도록 개선했습니다.

## 2. 어떤 작업을 했나요?

- Todo 컴포넌트에 수정 모드(isEditing) 상태 추가
- Edit 버튼 클릭 시 입력창 및 Save/Cancel 버튼 렌더링
- Save 클릭 시 수정된 이름 반영
- Cancel 클릭 시 수정 모드 취소
- tasks 상태를 localStorage에 저장
- 앱 로딩 시 localStorage에서 tasks를 불러와 초기화

## 3. 스타일 요소 수정

-  별도 수정사항 없음

## 4. 컴포넌트 설명

- Header : 제목(TodoMatic)과 서브타이틀 표시
- AddTodo : 할 일 입력창 및 추가 버튼
- Category : All / Active / Completed 필터 버튼
- TodoList : 필터링된 task 목록 출력
- Todo : 각 task 항목 출력 (체크박스, Edit, Delete, Save, Cancel 포함)

## 5. 완료 사항

- 기능 구현 (할 일 수정 기능 추가)
- tasks localStorage 저장 및 불러오기 기능 추가
- Context API를 통한 상태 관리 유지
- 기존 컴포넌트 구조 및 스타일 일관성 유지
- 브라우저 새로고침 이후에도 리스트 유지

## 6. 스크린샷
<img width="620" alt="image" src="https://github.com/user-attachments/assets/e78be03e-2108-4af2-a30d-bb93a4057c32" />


## 🔗 관련 이슈

fixes #52 